### PR TITLE
Add WAL staking prompt and query

### DIFF
--- a/sui/prompts/native_wal_staked.txt
+++ b/sui/prompts/native_wal_staked.txt
@@ -1,0 +1,1 @@
+Get daily token transfers within the last 7 dasy where function = 'stake_with_pool' and pacakge_id = '0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77' in sui.move_calls. Join with sui.balance_change and coin_type = '0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59::wal::WAL' and amount/1e9 with a -. Group by day.

--- a/sui/queries/native_wal_staked.sql
+++ b/sui/queries/native_wal_staked.sql
@@ -1,0 +1,15 @@
+SELECT
+  DATE (mc.time_stamp) AS transfer_date,
+  SUM(bc.amount / 1e27 * -1) AS total_transferred
+FROM
+  SUI.MOVE_CALLS mc
+  JOIN SUI.BALANCE_CHANGES bc ON mc.transaction_block_digest = bc.transaction_block_digest
+WHERE
+  mc.function = 'stake_with_pool'
+  AND mc.package_id = '0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77'
+  AND bc.coin_type = '0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59::wal::WAL'
+  AND mc.time_stamp >= date_sub (CAST('2025-04-11' AS DATE), 7)
+GROUP BY
+  DATE (mc.time_stamp)
+LIMIT
+  200;


### PR DESCRIPTION
## Summary
- create `native_wal_staked.txt` placeholder prompt describing WAL staking
- add `native_wal_staked.sql` query to sum WAL stake events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68643a72ff4083278a107d59ee65d2f2