### PR TITLE
Add query and prompt for login event activity

### DIFF
--- a/sui/prompts/6degrees_log_activity.txt
+++ b/sui/prompts/6degrees_log_activity.txt
@@ -1,0 +1,1 @@
+Count me transaction_block_digests and senders from the sui.events tales with the following packageid 0x2cdcc3b1306a49fcd5b8ccded57116ad86ab37a93ba9d91fa1ce06a8d22a21e9 where the type is 0x2cdcc3b1306a49fcd5b8ccded57116ad86ab37a93ba9d91fa1ce06a8d22a21e9::campaign::LoginEvent . group by day and order by date desc. Get the last 7 days only

--- a/sui/queries/6degrees_log_activity.sql
+++ b/sui/queries/6degrees_log_activity.sql
@@ -1,0 +1,16 @@
+SELECT
+  DATE (time_stamp) AS transaction_date,
+  COUNT(transaction_block_digest) AS transaction_count,
+  COUNT(sender) AS sender_count
+FROM
+  SUI.EVENTS
+WHERE
+  package_id = '0x2cdcc3b1306a49fcd5b8ccded57116ad86ab37a93ba9d91fa1ce06a8d22a21e9'
+  AND type_ = '0x2cdcc3b1306a49fcd5b8ccded57116ad86ab37a93ba9d91fa1ce06a8d22a21e9::campaign::LoginEvent'
+  AND time_stamp >= date_sub (CAST('2025-07-01' AS DATE), 7)
+GROUP BY
+  DATE (time_stamp)
+ORDER BY
+  transaction_date DESC
+LIMIT
+  200;


### PR DESCRIPTION
## Summary
- add a prompt describing how to pull 7 day login events
- add SQL file to count logins and senders per day

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646f9ffb28832797725bd1a9e6ba6a