### PR TITLE
Add BTC token holder activity prompt and query

### DIFF
--- a/sui/prompts/sui_btc_token_activity.txt
+++ b/sui/prompts/sui_btc_token_activity.txt
@@ -1,0 +1,15 @@
+Get current token holder counts over the last 60 days for a selected set of BTC-related tokens on Sui. Query sui.token_wallets where the coin_type is one of the following:
+
+0x3e8e9423d80e1774a7ca128fccd8bf5f1f7753be658c5e645929037f7c819040::lbtc::LBTC
+
+0x5f496ed5d9d045c5b788dc1bb85f54100f2ede11e46f6a232c29daada4c5bdb6::coin::COIN
+
+0xaafb102dd0902f5055cadecd687fb5b71ca82ef0e0285d90afde828ec58ca96b::btc::BTC
+
+0x027792d9fed7f9844eb4839566001bb6f6cb4804f66aa2da6fe1ee242d896881::coin::COIN
+
+0x876a4b7bce8aeaef60464c11f4026903e9afacab79b9b142686158aa86560b50::xbtc::XBTC
+
+0x77045f1b9f811a7a8fb9ebd085b5b0c55c5cb0d1520ff55f7037f89b5da9f5f1::TBTC::TBTC
+
+Map each coin_type to a readable token_symbol label using CASE logic. Count the number of distinct wallet addresses per token to get the number of token holders. Filter by time_stamp within the last 60 days and group results by token symbol. Limit the result to 10,000 rows.

--- a/sui/queries/sui_btc_token_activity.sql
+++ b/sui/queries/sui_btc_token_activity.sql
@@ -1,0 +1,28 @@
+SELECT
+  -- date_trunc('day', time_stamp) AS day,
+  CASE 
+    WHEN coin_type = '0x3e8e9423d80e1774a7ca128fccd8bf5f1f7753be658c5e645929037f7c819040::lbtc::LBTC' THEN 'LBTC'
+    WHEN coin_type = '0x5f496ed5d9d045c5b788dc1bb85f54100f2ede11e46f6a232c29daada4c5bdb6::coin::COIN' THEN 'stBTC'
+    WHEN coin_type = '0xaafb102dd0902f5055cadecd687fb5b71ca82ef0e0285d90afde828ec58ca96b::btc::BTC' THEN 'sbWBTC'
+    WHEN coin_type = '0x027792d9fed7f9844eb4839566001bb6f6cb4804f66aa2da6fe1ee242d896881::coin::COIN' THEN 'WBTC'
+    WHEN coin_type = '0x876a4b7bce8aeaef60464c11f4026903e9afacab79b9b142686158aa86560b50::xbtc::XBTC' THEN 'xBTC'
+    WHEN coin_type =
+      '0x77045f1b9f811a7a8fb9ebd085b5b0c55c5cb0d1520ff55f7037f89b5da9f5f1::TBTC::TBTC' THEN 'tBTC'
+    ELSE token_symbol
+  END AS token_symbol,
+  COUNT(DISTINCT wallet_address) AS token_holders
+FROM
+  SUI.TOKEN_WALLETS
+WHERE
+  coin_type IN (
+    '0x3e8e9423d80e1774a7ca128fccd8bf5f1f7753be658c5e645929037f7c819040::lbtc::LBTC',
+    '0x5f496ed5d9d045c5b788dc1bb85f54100f2ede11e46f6a232c29daada4c5bdb6::coin::COIN',
+    '0xaafb102dd0902f5055cadecd687fb5b71ca82ef0e0285d90afde828ec58ca96b::btc::BTC',
+    '0x027792d9fed7f9844eb4839566001bb6f6cb4804f66aa2da6fe1ee242d896881::coin::COIN',
+    '0x876a4b7bce8aeaef60464c11f4026903e9afacab79b9b142686158aa86560b50::xbtc::XBTC',
+    '0x77045f1b9f811a7a8fb9ebd085b5b0c55c5cb0d1520ff55f7037f89b5da9f5f1::TBTC::TBTC'
+  )
+  AND time_stamp BETWEEN CURRENT_DATE-60 AND current_date+1
+GROUP BY 1
+-- ORDER BY 1 DESC
+LIMIT 10000


### PR DESCRIPTION
## Summary
- add `sui_btc_token_activity.txt` describing a request for BTC token holder counts
- add matching SQL query `sui_btc_token_activity.sql`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687814f2d4ac8327b39d17902aa1427e